### PR TITLE
Removed Etm.Sdk

### DIFF
--- a/ErrorSubmissionModule.csproj
+++ b/ErrorSubmissionModule.csproj
@@ -254,12 +254,6 @@
   <ItemGroup>
     <Folder Include="ref\" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\etm.sdk\etm.sdk.csproj">
-      <Project>{93c52e88-5d50-43b0-8d19-a122dfa93d17}</Project>
-      <Name>etm.sdk</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>

--- a/EtmContext.cs
+++ b/EtmContext.cs
@@ -1,11 +1,10 @@
 ﻿using Blish_HUD.Contexts;
-using Etm.Sdk;
 using Sentry;
 
 namespace BhModule.Community.ErrorSubmissionModule {
-    public class EtmContext : Context, IEtmContext {
+    public class EtmContext : Context {
 
-        public IPerformanceTransaction StartPerformanceTransaction(string name, string operation, string description = null) {
+        public PerformanceTransaction StartPerformanceTransaction(string name, string operation, string description = null) {
             return this.State != ContextState.Expired && SentrySdk.IsEnabled
                        ? new PerformanceTransaction(SentrySdk.StartTransaction(name, operation, description))
                        : null;

--- a/PerformanceTransaction.cs
+++ b/PerformanceTransaction.cs
@@ -1,8 +1,7 @@
-﻿using Etm.Sdk;
-using Sentry;
+﻿using Sentry;
 
 namespace BhModule.Community.ErrorSubmissionModule {
-    public class PerformanceTransaction : IPerformanceTransaction {
+    public class PerformanceTransaction {
 
         private readonly ISpan _transaction;
 
@@ -12,7 +11,7 @@ namespace BhModule.Community.ErrorSubmissionModule {
             _transaction = transaction;
         }
 
-        public IPerformanceTransaction StartChildPerformanceTransaction(string operation, string description = null) {
+        public PerformanceTransaction StartChildPerformanceTransaction(string operation, string description = null) {
             return !_transaction.IsFinished 
                        ? new PerformanceTransaction(_transaction.StartChild(operation, description))
                        : null;


### PR DESCRIPTION
Since there is an oversight in the core implementation, Etm.Sdk wasn't going to work as intended anyways.  Removing for now.
